### PR TITLE
Modbus ascii

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## About
 
-This [Go](http://golang.org/) package provides [Modbus](http://en.wikipedia.org/wiki/Modbus) access for client (master) applications to communicate with server (slave) devices, over both [TCP/IP](http://www.modbus.org/docs/Modbus_Messaging_Implementation_Guide_V1_0b.pdf) and [Serial Line/RTU](http://www.modbus.org/docs/Modbus_over_serial_line_V1_02.pdf) frame protocols.
+This [Go](http://golang.org/) package provides [Modbus](http://en.wikipedia.org/wiki/Modbus) access for client (master) applications to communicate with server (slave) devices, over both [TCP/IP](http://www.modbus.org/docs/Modbus_Messaging_Implementation_Guide_V1_0b.pdf) and [Serial Line/RTU/ASCII](http://www.modbus.org/docs/Modbus_over_serial_line_V1_02.pdf) frame protocols.
 
 Note that in modbus terminology, _client_ refers to the __master__ application or device, and the _server_ is the __slave__ waiting to respond to instructions, as shown in this transaction diagram:
 
@@ -22,10 +22,11 @@ go get github.com/dpapathanasiou/go-modbus
 Next, build and run the examples:
 
  * [rtu-client.go](examples/rtu-client.go) for an RTU example
+ * [ascii-client.go](examples/ascii-client.go) for an ASCII example
  * [tcp-client.go](examples/tcp-client.go) for a TCP/IP example
 
 
-### Enabling the USB Serial Port adapter (RS-232) for RTU Access
+### Enabling the USB Serial Port adapter (RS-232) for RTU/ASCII Access
 
 Slave devices which have [USB](http://en.wikipedia.org/wiki/Usb) ports for RTU access will not work immediately upon hot-plugging into a master computer.
 
@@ -66,6 +67,7 @@ $ sudo dmesg | tail
 - [Modbus Interface Tutorial](http://www.lammertbies.nl/comm/info/modbus.html)
 - [Modbus TCP/IP Overview](http://www.rtaautomation.com/modbustcp/)
 - [Modbus RTU Protocol Overview](http://www.rtaautomation.com/modbusrtu/)
+- [Modbus ASCII Protocol Overview](http://www.simplymodbus.ca/ASCII.htm)
 
 ## Acknowledgements
 - [Lubia Yang](http://www.lubia.me) for the [original modbus code](https://github.com/lubia/modbus) in Go

--- a/examples/ascii-client.go
+++ b/examples/ascii-client.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"github.com/dpapathanasiou/go-modbus"
+	"log"
+)
+
+func main() {
+
+	// get the device serial port from the command line
+	var (
+		serialPort    string
+		slaveDevice   int
+		startAddr     int
+		numBytes      int
+		baudRate      int
+		responsePause int
+	)
+
+	const (
+		defaultPort          = ""
+		defaultSlave         = 1
+		defaultStartAddress  = 3030
+		defaultNumBytes      = 16
+		defaultBaudRate      = 9600
+		defaultResponsePause = 300
+	)
+
+	flag.StringVar(&serialPort, "serial", defaultPort, "Serial port (RS485) to use, e.g., /dev/ttyS0 (try \"dmesg | grep tty\" to find)")
+	flag.IntVar(&slaveDevice, "slave", defaultSlave, fmt.Sprintf("Slave device number (default is %d)", defaultSlave))
+	flag.IntVar(&startAddr, "start", defaultStartAddress, fmt.Sprintf("Start address (default is %d)", defaultStartAddress))
+	flag.IntVar(&numBytes, "bytes", defaultNumBytes, fmt.Sprintf("Number of bytes to read from the start address (default is %d)", defaultNumBytes))
+	flag.IntVar(&baudRate, "baud", defaultBaudRate, fmt.Sprintf("Baud Rate (default is %d)", defaultBaudRate))
+	flag.IntVar(&responsePause, "pause", defaultResponsePause, fmt.Sprintf("Device Response Pause in milliseconds (default is %d)", defaultResponsePause))
+	flag.Parse()
+
+	if len(serialPort) > 0 {
+
+		// turn on the debug trace option, to see what is being transmitted
+		trace := true
+		ctx, cerr := modbusclient.ConnectRTU(serialPort, baudRate)
+		if cerr != nil {
+			log.Println(fmt.Sprintf("RTU Connection Err: %s", cerr))
+		} else {
+			// attempt to read the [startAddr] address register on
+			// slave device number [slaveDevice] via the [serialDevice]
+			readResult, readErr := modbusclient.RTURead(ctx, byte(slaveDevice), modbusclient.FUNCTION_READ_HOLDING_REGISTERS, uint16(startAddr), uint16(numBytes), responsePause, trace)
+			if readErr != nil {
+				log.Println(readErr)
+			} else {
+				log.Println(fmt.Sprintf("Rx: %x", readResult))
+
+				// Skip past the reply headers, and decode each of the data hi/lo byte pairs into integers
+				var (
+					sliceStart, sliceStop int
+					data                  int16
+					decodeErr             error
+				)
+
+				for i := 0; i < int(readResult[2]); i++ {
+					// take the next two bytes, if available
+					sliceStart = 3 + i
+					sliceStop = 3 + i + 2
+
+					// decode them into integers
+					data, decodeErr = modbusclient.DecodeHiLo(readResult[sliceStart:sliceStop])
+					if decodeErr != nil {
+						log.Println(decodeErr)
+					} else {
+						log.Println(fmt.Sprintf("Decoded int = %d (from pair of data bytes: %x)", data, readResult[sliceStart:sliceStop]))
+					}
+				}
+			}
+			modbusclient.DisconnectRTU(ctx)
+		}
+		/*
+			// attempt to read the [startAddr] address register on
+			// slave device number [slaveDevice] via the [serialDevice]
+			readResult, readErr := modbusclient.RTURead(serialPort, byte(slaveDevice), modbusclient.FUNCTION_READ_HOLDING_REGISTERS, uint16(startAddr), uint16(numBytes), baudRate, responsePause, trace)
+			if readErr != nil {
+				log.Println(readErr)
+			}
+			log.Println(fmt.Sprintf("Rx: %x", readResult))
+
+			// Skip past the reply headers, and take a slice of the first data pair returned,
+			// to decode their high/low bytes into the corresponding integer value
+			firstInt, decodeErr := modbusclient.DecodeHiLo(readResult[3:5])
+			if decodeErr != nil {
+				log.Println(decodeErr)
+			} else {
+				log.Println(fmt.Sprintf("Decoded int = %d (from 1st pair of data bytes: %x)", firstInt, readResult[3:5]))
+			}*/
+
+	} else {
+
+		// display the command line usage requirements
+		flag.PrintDefaults()
+
+	}
+
+}

--- a/examples/ascii-client.go
+++ b/examples/ascii-client.go
@@ -41,7 +41,6 @@ func main() {
 
 		// turn on the debug trace option, to see what is being transmitted
 		trace := true
-                fmt.Println(serialPort, baudRate)
 		ctx, cerr := modbusclient.ConnectASCII(serialPort, baudRate)
 		if cerr != nil {
 			log.Println(fmt.Sprintf("ASCII Connection Err: %s", cerr))

--- a/examples/ascii-client.go
+++ b/examples/ascii-client.go
@@ -3,8 +3,9 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/dpapathanasiou/go-modbus"
 	"log"
+
+	"github.com/AdamSLevy/go-modbus"
 )
 
 func main() {
@@ -40,13 +41,14 @@ func main() {
 
 		// turn on the debug trace option, to see what is being transmitted
 		trace := true
-		ctx, cerr := modbusclient.ConnectRTU(serialPort, baudRate)
+                fmt.Println(serialPort, baudRate)
+		ctx, cerr := modbusclient.ConnectASCII(serialPort, baudRate)
 		if cerr != nil {
-			log.Println(fmt.Sprintf("RTU Connection Err: %s", cerr))
+			log.Println(fmt.Sprintf("ASCII Connection Err: %s", cerr))
 		} else {
 			// attempt to read the [startAddr] address register on
 			// slave device number [slaveDevice] via the [serialDevice]
-			readResult, readErr := modbusclient.RTURead(ctx, byte(slaveDevice), modbusclient.FUNCTION_READ_HOLDING_REGISTERS, uint16(startAddr), uint16(numBytes), responsePause, trace)
+			readResult, readErr := modbusclient.ASCIIRead(ctx, byte(slaveDevice), modbusclient.FUNCTION_READ_HOLDING_REGISTERS, uint16(startAddr), uint16(numBytes), responsePause, trace)
 			if readErr != nil {
 				log.Println(readErr)
 			} else {
@@ -73,12 +75,12 @@ func main() {
 					}
 				}
 			}
-			modbusclient.DisconnectRTU(ctx)
+			modbusclient.DisconnectASCII(ctx)
 		}
 		/*
 			// attempt to read the [startAddr] address register on
 			// slave device number [slaveDevice] via the [serialDevice]
-			readResult, readErr := modbusclient.RTURead(serialPort, byte(slaveDevice), modbusclient.FUNCTION_READ_HOLDING_REGISTERS, uint16(startAddr), uint16(numBytes), baudRate, responsePause, trace)
+			readResult, readErr := modbusclient.ASCIIRead(serialPort, byte(slaveDevice), modbusclient.FUNCTION_READ_HOLDING_REGISTERS, uint16(startAddr), uint16(numBytes), baudRate, responsePause, trace)
 			if readErr != nil {
 				log.Println(readErr)
 			}

--- a/modbus-ascii.go
+++ b/modbus-ascii.go
@@ -6,9 +6,9 @@
 package modbusclient
 
 import (
+	"bytes"
+	"encoding/hex"
 	"fmt"
-        "encoding/hex"
-        "bytes"
 	"github.com/tarm/goserial"
 	"io"
 	"log"
@@ -16,19 +16,19 @@ import (
 )
 
 func Lrc(data []byte) uint8 {
-    return lrc(data)
+	return lrc(data)
 }
 
 // Modbus ASCII does not use CRC, but Longitudinal Redundancy Check.
 // lrc computes and returns the 2's compliment (-) of the sum of the given byte
 // array modulo 256
 func lrc(data []byte) uint8 {
-        var sum uint8= 0
-        var lrc8 uint8 = 0
-        for _, b := range data {
-                sum += b
-        }
-        lrc8 = uint8(-int8(sum))
+	var sum uint8 = 0
+	var lrc8 uint8 = 0
+	for _, b := range data {
+		sum += b
+	}
+	lrc8 = uint8(-int8(sum))
 	return lrc8
 }
 
@@ -40,9 +40,9 @@ func (frame *ASCIIFrame) GenerateASCIIFrame() []byte {
 	packetLen := 7
 	if len(frame.Data) > 0 {
 		packetLen += len(frame.Data) + 1
-                if packetLen > ASCII_FRAME_MAXSIZE {
-                    packetLen = ASCII_FRAME_MAXSIZE
-                }
+		if packetLen > ASCII_FRAME_MAXSIZE {
+			packetLen = ASCII_FRAME_MAXSIZE
+		}
 	}
 
 	packet := make([]byte, packetLen)
@@ -64,17 +64,17 @@ func (frame *ASCIIFrame) GenerateASCIIFrame() []byte {
 	packet[bytesUsed] = byte(packet_lrc)
 	bytesUsed += 1
 
-        // Convert raw bytes to ASCII packet
-        ascii_packet := make([]byte, bytesUsed*2 + 3)
-        hex.Encode(ascii_packet[1:], packet)
+	// Convert raw bytes to ASCII packet
+	ascii_packet := make([]byte, bytesUsed*2+3)
+	hex.Encode(ascii_packet[1:], packet)
 
-        asciiBytesUsed := bytesUsed*2 + 1
+	asciiBytesUsed := bytesUsed*2 + 1
 
-        // Frame the packet
-        ascii_packet[0                 ] = ':'  // 0x3A
-        ascii_packet[asciiBytesUsed    ] = '\r' // CR 0x0D
-        ascii_packet[asciiBytesUsed + 1] = '\n' // LF 0x0A
-        asciiBytesUsed += 2
+	// Frame the packet
+	ascii_packet[0] = ':'                 // 0x3A
+	ascii_packet[asciiBytesUsed] = '\r'   // CR 0x0D
+	ascii_packet[asciiBytesUsed+1] = '\n' // LF 0x0A
+	asciiBytesUsed += 2
 
 	return bytes.ToUpper(ascii_packet[:asciiBytesUsed])
 }
@@ -140,21 +140,21 @@ func viaASCII(connection io.ReadWriteCloser, fnValidator func(byte) bool, slaveA
 			return []byte{}, rerr
 		}
 
-                // check the framing of the response
-                if ascii_response[0] != ':'   ||
-                   ascii_response[ascii_n -2] != '\r' ||
-                   ascii_response[ascii_n -1] != '\n' {
+		// check the framing of the response
+		if ascii_response[0] != ':' ||
+			ascii_response[ascii_n-2] != '\r' ||
+			ascii_response[ascii_n-1] != '\n' {
 			if debug {
 				log.Println("ASCII Response Framing Invalid")
-                                log.Println(fmt.Sprintf("%s", ascii_response))
+				log.Println(fmt.Sprintf("%s", ascii_response))
 			}
 			return []byte{}, MODBUS_EXCEPTIONS[EXCEPTION_UNSPECIFIED]
-                }
+		}
 
-                // convert to raw bytes
-                raw_n := (ascii_n - 3) / 2
-                response := make([]byte, raw_n)
-                hex.Decode(response, ascii_response[1:ascii_n-2])
+		// convert to raw bytes
+		raw_n := (ascii_n - 3) / 2
+		response := make([]byte, raw_n)
+		hex.Decode(response, ascii_response[1:ascii_n-2])
 
 		// check the validity of the response
 		if response[0] != frame.SlaveAddress || response[1] != frame.FunctionCode {
@@ -184,7 +184,7 @@ func viaASCII(connection io.ReadWriteCloser, fnValidator func(byte) bool, slaveA
 				log.Println("ASCII Response Invalid: Bad Checksum")
 			}
 			// return the response bytes anyway, and let the caller decide
-                        return response, MODBUS_EXCEPTIONS[EXCEPTION_BAD_CHECKSUM]
+			return response, MODBUS_EXCEPTIONS[EXCEPTION_BAD_CHECKSUM]
 		}
 
 		// return only the number of bytes read

--- a/modbus-ascii.go
+++ b/modbus-ascii.go
@@ -1,0 +1,175 @@
+// Package modbusclient provides modbus Serial Line/RTU and TCP/IP access
+// for client (master) applications to communicate with server (slave)
+// devices. Logic specifically in this file implements the Serial Line/RTU
+// protocol.
+
+package modbusclient
+
+import (
+	"fmt"
+	"github.com/tarm/goserial"
+	"io"
+	"log"
+	"time"
+)
+
+// crc computes and returns a cyclic redundancy check of the given byte array
+func crc(data []byte) uint16 {
+	var crc16 uint16 = 0xffff
+	l := len(data)
+	for i := 0; i < l; i++ {
+		crc16 ^= uint16(data[i])
+		for j := 0; j < 8; j++ {
+			if crc16&0x0001 > 0 {
+				crc16 = (crc16 >> 1) ^ 0xA001
+			} else {
+				crc16 >>= 1
+			}
+		}
+	}
+	return crc16
+}
+
+// GenerateRTUFrame is a method corresponding to a RTUFrame object which
+// returns a byte array representing the associated serial line/RTU
+// application data unit (ADU)
+func (frame *RTUFrame) GenerateRTUFrame() []byte {
+
+	packetLen := 8
+	if len(frame.Data) > 0 {
+		packetLen = RTU_FRAME_MAXSIZE
+	}
+
+	packet := make([]byte, packetLen)
+	packet[0] = frame.SlaveAddress
+	packet[1] = frame.FunctionCode
+	packet[2] = byte(frame.StartRegister >> 8)       // (High Byte)
+	packet[3] = byte(frame.StartRegister & 0xff)     // (Low Byte)
+	packet[4] = byte(frame.NumberOfRegisters >> 8)   // (High Byte)
+	packet[5] = byte(frame.NumberOfRegisters & 0xff) // (Low Byte)
+	bytesUsed := 6
+
+	for i := 0; i < len(frame.Data); i++ {
+		packet[(bytesUsed + i)] = frame.Data[i]
+	}
+	bytesUsed += len(frame.Data)
+
+	// add the crc to the end
+	packet_crc := crc(packet[:bytesUsed])
+	packet[bytesUsed] = byte(packet_crc & 0xff)
+	packet[(bytesUsed + 1)] = byte(packet_crc >> 8)
+	bytesUsed += 2
+
+	return packet[:bytesUsed]
+}
+
+// ConnectRTU attempts to access the Serial Device for subsequent
+// RTU writes and response reads from the modbus slave device
+func ConnectRTU(serialDevice string, baudRate int) (io.ReadWriteCloser, error) {
+	conf := &serial.Config{Name: serialDevice, Baud: baudRate}
+	ctx, err := serial.OpenPort(conf)
+	return ctx, err
+}
+
+// DisconnectRTU closes the underlying Serial Device connection
+func DisconnectRTU(ctx io.ReadWriteCloser) {
+	ctx.Close()
+}
+
+// viaRTU is a private method which applies the given function validator,
+// to make sure the functionCode passed is valid for the operation
+// desired. If correct, it creates an RTUFrame given the corresponding
+// information, attempts to open the serialDevice, and if successful, transmits
+// it to the modbus server (slave device) specified by the given serial connection,
+// and returns a byte array of the slave device's reply, and error (if any)
+func viaRTU(connection io.ReadWriteCloser, fnValidator func(byte) bool, slaveAddress, functionCode byte, startRegister, numRegisters uint16, data []byte, timeOut int, debug bool) ([]byte, error) {
+	if fnValidator(functionCode) {
+		frame := new(RTUFrame)
+		frame.TimeoutInMilliseconds = timeOut
+		frame.SlaveAddress = slaveAddress
+		frame.FunctionCode = functionCode
+		frame.StartRegister = startRegister
+		frame.NumberOfRegisters = numRegisters
+		if len(data) > 0 {
+			frame.Data = data
+		}
+
+		// generate the ADU from the RTU frame
+		adu := frame.GenerateRTUFrame()
+		if debug {
+			log.Println(fmt.Sprintf("Tx: %x", adu))
+		}
+
+		// transmit the ADU to the slave device via the
+		// serial port represented by the fd pointer
+		_, werr := connection.Write(adu)
+		if werr != nil {
+			if debug {
+				log.Println(fmt.Sprintf("RTU Write Err: %s", werr))
+			}
+			return []byte{}, werr
+		}
+
+		// allow the slave device adequate time to respond
+		time.Sleep(time.Duration(frame.TimeoutInMilliseconds) * time.Millisecond)
+
+		// then attempt to read the reply
+		response := make([]byte, RTU_FRAME_MAXSIZE)
+		n, rerr := connection.Read(response)
+		if rerr != nil {
+			if debug {
+				log.Println(fmt.Sprintf("RTU Read Err: %s", rerr))
+			}
+			return []byte{}, rerr
+		}
+
+		// check the validity of the response
+		if response[0] != frame.SlaveAddress || response[1] != frame.FunctionCode {
+			if debug {
+				log.Println("RTU Response Invalid")
+			}
+			if response[0] == frame.SlaveAddress && (response[1]&0x7f) == frame.FunctionCode {
+				switch response[2] {
+				case EXCEPTION_ILLEGAL_FUNCTION:
+					return []byte{}, MODBUS_EXCEPTIONS[EXCEPTION_ILLEGAL_FUNCTION]
+				case EXCEPTION_DATA_ADDRESS:
+					return []byte{}, MODBUS_EXCEPTIONS[EXCEPTION_DATA_ADDRESS]
+				case EXCEPTION_DATA_VALUE:
+					return []byte{}, MODBUS_EXCEPTIONS[EXCEPTION_DATA_VALUE]
+				case EXCEPTION_SLAVE_DEVICE_FAILURE:
+					return []byte{}, MODBUS_EXCEPTIONS[EXCEPTION_SLAVE_DEVICE_FAILURE]
+				}
+			}
+			return []byte{}, MODBUS_EXCEPTIONS[EXCEPTION_UNSPECIFIED]
+		}
+
+		// confirm the checksum (crc)
+		response_crc := crc(response[:(n - 2)])
+		if response[(n-2)] != byte((response_crc&0xff)) ||
+			response[(n-1)] != byte((response_crc>>8)) {
+			// crc failed (odd that there's no specific code for it)
+			if debug {
+				log.Println("RTU Response Invalid: Bad Checksum")
+			}
+			// return the response bytes anyway, and let the caller decide
+			return response[:n], MODBUS_EXCEPTIONS[EXCEPTION_BAD_CHECKSUM]
+		}
+
+		// return only the number of bytes read
+		return response[:n], nil
+	}
+
+	return []byte{}, MODBUS_EXCEPTIONS[EXCEPTION_ILLEGAL_FUNCTION]
+}
+
+// RTURead performs the given modbus Read function over RTU to the given
+// serialDevice, using the given frame data
+func RTURead(serialDeviceConnection io.ReadWriteCloser, slaveAddress, functionCode byte, startRegister, numRegisters uint16, timeOut int, debug bool) ([]byte, error) {
+	return viaRTU(serialDeviceConnection, ValidReadFunction, slaveAddress, functionCode, startRegister, numRegisters, []byte{}, timeOut, debug)
+}
+
+// RTUWrite performs the given modbus Write function over RTU to the given
+// serialDevice, using the given frame data
+func RTUWrite(serialDeviceConnection io.ReadWriteCloser, slaveAddress, functionCode byte, startRegister, numRegisters uint16, data []byte, timeOut int, debug bool) ([]byte, error) {
+	return viaRTU(serialDeviceConnection, ValidWriteFunction, slaveAddress, functionCode, startRegister, numRegisters, data, timeOut, debug)
+}

--- a/modbus-core.go
+++ b/modbus-core.go
@@ -11,9 +11,10 @@ import (
 )
 
 const (
-	MODBUS_PORT       = 502
-	RTU_FRAME_MAXSIZE = 512
-	TCP_FRAME_MAXSIZE = 260
+	MODBUS_PORT         = 502
+	RTU_FRAME_MAXSIZE   = 512
+	ASCII_FRAME_MAXSIZE = 512
+	TCP_FRAME_MAXSIZE   = 260
 
 	FUNCTION_READ_COILS                    = 0x01
 	FUNCTION_READ_DISCRETE_INPUTS          = 0x02
@@ -95,6 +96,15 @@ type TCPFrame struct {
 }
 
 type RTUFrame struct {
+	TimeoutInMilliseconds int
+	SlaveAddress          byte
+	FunctionCode          byte
+	StartRegister         uint16
+	NumberOfRegisters     uint16
+	Data                  []byte
+}
+
+type ASCIIFrame struct {
 	TimeoutInMilliseconds int
 	SlaveAddress          byte
 	FunctionCode          byte


### PR DESCRIPTION
Please consider merging this addition to your modbus library. 
I implemented the Modbus ASCII protocol.

I pretty much copy and pasted the RTU client and changed every instance of the word RTU to ASCII. Then I set about the real work of writing the LRC checksum (which modbus ascii uses instead of CRC16), converting the raw binary to its upper case ASCII hex representation, and adding the ':' header and 'CR LF' footer.

Appropriate changes were made to the viaASCII function for parsing the response.

I tested the implementation against the [diagslave Modbus slave simulator](http://www.modbusdriver.com/diagslave.html).

I added mention of modbus ASCII to the README and an example ASCII client program.